### PR TITLE
docs: 修正 README 浏览器操控和点击穿透的完成状态描述

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ L 星团深处，由纳米机器人构成的灰蛊风暴，在漫长的等待中
 | 🖥️ | **桌面宠物** | 透明窗口 · 鼠标穿透 · 拖拽 · 高 DPI · 系统托盘 | ✅ |
 | 📦 | **一键启动** | Electron 打包 · `build.bat` 构建 exe | ✅ |
 | 🎤 | **自定义音色** | 音色克隆 · 试听 · 管理 UI | ✅ |
-| 🌐 | **浏览器操控** | Playwright + function calling · 并行搜索 | ✅ |
+| 🌐 | **浏览器操控** | Playwright + function calling · 并行搜索（需 `uv sync --extra browser` + 配置启用） | ✅ |
 | 🖱️ | **桌面操控** | pyautogui · 截图定位 · 操作序列 | 规划中 |
 | 📺 | **Live2D 直播** | OBS 推流 · 弹幕互动 · 自主直播 | 规划中 |
 | 🤖 | **多 Agent 协作** | 底层按需调度多个 AI CLI，对你透明 | 规划中 |
@@ -239,7 +239,7 @@ cd frontend/desktop && npm start
 | TTS | 硅基流动 CosyVoice2 · 自定义音色克隆 · edge-tts（备用） |
 | VAD | Silero VAD（onnxruntime 本地推理） |
 | 截屏 | koffi Win32 API 纯内存截屏 + Vision API · 差异检测 |
-| 浏览器 | Playwright · function calling · 并行搜索 |
+| 浏览器 | Playwright · function calling · 并行搜索（可选，需额外安装） |
 | 包管理 | uv（Python） · npm（Node） |
 
 ---
@@ -272,8 +272,8 @@ cd frontend/desktop && npm start
 
 - [x] 屏幕感知（截图 + Vision · 差异检测 · 主动播报）
 - [x] 自定义音色克隆（音色上传 · 试听缓存 · 管理 UI）
-- [x] 浏览器操控（Playwright + function calling · 并行搜索）
-- [x] 像素级点击穿透（pixi readPixels 透明检测）
+- [x] 浏览器操控（Playwright + function calling · 并行搜索；需 `uv sync --extra browser` + `browser.enabled: true`）
+- [x] 桌面宠物点击穿透（Electron 透明窗口 + 前端命中检测；Linux 回退为全窗口可交互）
 - [ ] 桌面操控（pyautogui）
 - [ ] Live2D 直播（OBS 推流 · 弹幕互动 · 自主直播）
 - [ ] 聊天历史清空按钮 / 菜单项


### PR DESCRIPTION
## 改了什么

回应 PR #48 的 bot review 两条评论：

1. **浏览器操控**：补充需要 `uv sync --extra browser` + `browser.enabled: true` 才能启用的前提条件
2. **点击穿透**：移除不准确的 `pixi readPixels` 描述，改为实际实现方案（Electron 透明窗口 + 前端命中检测），注明 Linux 回退行为

涉及 README 三处表格/列表的同步修正。