### PR TITLE
feat: Live2D 模型 Ctrl+滚轮缩放及位置持久化

### DIFF
--- a/docs/design/2026-03-20-scroll-zoom.md
+++ b/docs/design/2026-03-20-scroll-zoom.md
@@ -1,0 +1,83 @@
+# 设计文档：Live2D 模型 Ctrl+滚轮缩放
+
+> 日期：2026-03-20
+> 状态：待确认
+
+## 功能描述
+
+用户可通过 `Ctrl + 鼠标滚轮` 在桌面上对 Live2D 模型进行缩放，缩放以鼠标为中心点，设置持久化，支持重置。
+
+## 验收标准
+
+1. Ctrl+向上滚轮 → 模型放大，缩放中心为当前鼠标位置
+2. Ctrl+向下滚轮 → 模型缩小，缩放中心为当前鼠标位置
+3. 普通滚轮（无 Ctrl）→ 不触发缩放（忽略）
+4. 缩放范围：`userScale` 限制在 [0.3, 3.0]，超出范围停止缩放
+5. 拖拽和缩放互不干扰
+6. 缩放倍率 (`userScale`) 和位置偏移 (`userOffsetX/Y`) 持久化到 `render-settings.json`
+7. 重启后自动恢复上次缩放/位置
+8. 设置页新增"重置位置和大小"按钮，点击恢复 `fitModel()` 默认值并清除持久化偏移
+
+## 技术方案
+
+### 核心数据结构
+
+`render-settings.json` 新增三个字段：
+```json
+{
+  "hiDpi": false,
+  "bubbleBlur": true,
+  "userScale": 1.0,
+  "userOffsetX": 0,
+  "userOffsetY": 0
+}
+```
+
+- `userScale`：用户缩放倍率（相对于 `fitModel()` 计算的基准 scale，乘积为最终 scale）
+- `userOffsetX/Y`：相对于 `fitModel()` 计算的基准位置的像素偏移
+
+这样设计的好处：分辨率无关，`fitModel()` 先算出 baseScale/baseX/baseY，再叠加用户偏好。
+
+### 缩放以鼠标为中心的数学
+
+```
+设鼠标位置为 (mx, my)，当前模型位置为 (x, y)，当前 scale 为 s，新 scale 为 s'
+
+// 鼠标在模型坐标系中的偏移
+offsetX = mx - x
+offsetY = my - y
+
+// 缩放后调整位置，使鼠标指向模型的同一点
+x' = mx - offsetX * (s' / s)
+y' = my - offsetY * (s' / s)
+```
+
+### 改动文件清单
+
+| 文件 | 改动内容 |
+|------|---------|
+| `frontend/desktop/renderer/live2d-renderer.js` | ① 加载时读取 `userScale/Offset` 并在 `fitModel()` 后应用<br>② 在 `drag-overlay` 上注册 `wheel` 事件，Ctrl+滚轮执行缩放<br>③ 缩放后防抖写入 `render-settings` |
+| `frontend/desktop/main.js` | 新增 `render-settings:reset-model-transform` IPC handler，清除 `userScale/Offset` 并通知主窗口 |
+| `frontend/desktop/preload.js` | 新增 `updateRenderSettings`（`render-settings:update`）和 `resetModelTransform`（`render-settings:reset-model-transform`） |
+| `frontend/desktop/preload-settings.js` | 新增 `resetModelTransform: () => ipcRenderer.invoke("render-settings:reset-model-transform")` |
+| `frontend/desktop/renderer/settings.html` | 在渲染设置区域新增"重置位置和大小"按钮及对应 JS |
+
+### 持久化策略
+
+- 防抖 500ms 写入，避免高频滚动引发频繁磁盘写
+- 写入通过已有的 `render-settings:update` IPC 通道（主进程持有文件句柄）
+- 重置时写入 `{userScale: 1.0, userOffsetX: 0, userOffsetY: 0}` 并向主窗口发送 `render-settings-changed` 事件
+
+### 穿透兼容性
+
+- 鼠标在模型有效像素上时 `setIgnoreMouseEvents(false)` 已生效 → `wheel` 事件正常触发
+- 无 Ctrl 时不缩放，但 Electron 仍然捕获该滚轮事件（架构限制，可接受）
+- 不新增 IPC 通道用于实时写（防抖后用已有 `render-settings:update`）
+
+## 风险点
+
+| 风险 | 处置 |
+|------|------|
+| 模型加载前滚动（`live2dModel = null`）| wheel handler 开头检查 `if (!live2dModel) return` |
+| 防抖期间关闭应用 | 主进程 `before-quit` 已有 `saveHistoryToDisk`，同理需在关闭前 flush 缓存的 transform；或简化：滚动时同步写入（量不大） |
+| preload.js 未暴露 `resetModelTransform` | 需检查 preload.js 是否已有 `saveRenderSettings`，按现有 pattern 补充 |

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -1036,6 +1036,16 @@ function createWindow() {
     return merged;
   });
 
+  ipcMain.handle("render-settings:reset-model-transform", () => {
+    const current = loadRenderSettings();
+    const reset = { ...current, userScale: 1.0, userOffsetX: 0, userOffsetY: 0 };
+    saveRenderSettings(reset);
+    if (win && !win.isDestroyed()) {
+      win.webContents.send("render-settings-changed", reset);
+    }
+    return reset;
+  });
+
   // ── 音色管理 IPC ──
   ipcMain.handle("voice:list", async () => {
     try {

--- a/frontend/desktop/preload-settings.js
+++ b/frontend/desktop/preload-settings.js
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld("settingsAPI", {
   updateDesktopSettings: (data) => ipcRenderer.invoke("settings:update-desktop", data),
   getRenderSettings: () => ipcRenderer.invoke("render-settings:get"),
   updateRenderSettings: (data) => ipcRenderer.invoke("render-settings:update", data),
+  resetModelTransform: () => ipcRenderer.invoke("render-settings:reset-model-transform"),
   // 音色管理
   listVoices: () => ipcRenderer.invoke("voice:list"),
   uploadVoice: (data) => ipcRenderer.invoke("voice:upload", data),

--- a/frontend/desktop/preload.js
+++ b/frontend/desktop/preload.js
@@ -18,6 +18,8 @@ contextBridge.exposeInMainWorld("greywind", {
   onScreenFrame: (fn) => ipcRenderer.on("screen:frame", (_, data) => fn(data)),
   onRefreshClickShape: (fn) => ipcRenderer.on("refresh-click-shape", () => fn()),
   getRenderSettings: () => ipcRenderer.invoke("render-settings:get"),
+  updateRenderSettings: (data) => ipcRenderer.invoke("render-settings:update", data),
+  resetModelTransform: () => ipcRenderer.invoke("render-settings:reset-model-transform"),
   onRenderSettingsChanged: (fn) => ipcRenderer.on("render-settings-changed", (_, data) => fn(data)),
   onClearHistory: (fn) => ipcRenderer.on("chat-history:clear", () => fn()),
 });

--- a/frontend/desktop/renderer/live2d-renderer.js
+++ b/frontend/desktop/renderer/live2d-renderer.js
@@ -148,8 +148,9 @@ async function initLive2D() {
       document.body.dataset.modelReady = "true";
       modelBaseWidth = model.internalModel.originalWidth;
       modelBaseHeight = model.internalModel.originalHeight;
-      // 切换模型时重置用户偏移，避免旧模型的偏移量污染新模型
+      // 切换模型时重置用户偏移，避免旧模型的偏移量污染新模型，并立即写盘
       userTransform = { userScale: 1.0, userOffsetX: 0, userOffsetY: 0 };
+      window.greywind?.updateRenderSettings?.({ userScale: 1.0, userOffsetX: 0, userOffsetY: 0 });
       fitModel(app, model);
       app.stage.addChild(model);
       if (placeholder) placeholder.style.display = "none";
@@ -331,3 +332,16 @@ initLive2D();
     isIgnoring = true;
   });
 })();
+
+// 退出前 flush 防抖 timer，避免拖拽/缩放后立即关闭导致 transform 丢失
+window.addEventListener("beforeunload", () => {
+  if (saveTransformTimer) {
+    clearTimeout(saveTransformTimer);
+    saveTransformTimer = null;
+    window.greywind?.updateRenderSettings?.({
+      userScale: userTransform.userScale,
+      userOffsetX: userTransform.userOffsetX,
+      userOffsetY: userTransform.userOffsetY,
+    });
+  }
+});

--- a/frontend/desktop/renderer/live2d-renderer.js
+++ b/frontend/desktop/renderer/live2d-renderer.js
@@ -13,6 +13,39 @@ let modelBaseHeight = 0;
 // PIXI app 引用，供穿透检测读 GL context
 let pixiApp = null;
 
+// 用户自定义缩放/位置（相对于 fitModel 基准值的倍率和偏移）
+let userTransform = { userScale: 1.0, userOffsetX: 0, userOffsetY: 0 };
+// fitModel 计算出的基准值，用于 userTransform 的参照
+let modelBaseScale = 1;
+let modelFitX = 0;
+let modelFitY = 0;
+
+// 缩放范围常量
+const SCALE_MIN = 0.3;
+const SCALE_MAX = 3.0;
+const SCALE_STEP = 0.1;
+
+// 持久化防抖 timer（模块级，wheel 和 drag 共享同一 timer）
+let saveTransformTimer = null;
+function saveTransformDebounced() {
+  if (saveTransformTimer) clearTimeout(saveTransformTimer);
+  saveTransformTimer = setTimeout(() => {
+    saveTransformTimer = null;
+    window.greywind?.updateRenderSettings?.({
+      userScale: userTransform.userScale,
+      userOffsetX: userTransform.userOffsetX,
+      userOffsetY: userTransform.userOffsetY,
+    });
+  }, 500);
+}
+
+function applyUserTransform(model) {
+  if (!model) return;
+  model.scale.set(modelBaseScale * userTransform.userScale);
+  model.x = modelFitX + userTransform.userOffsetX;
+  model.y = modelFitY + userTransform.userOffsetY;
+}
+
 const { Live2DModel } = PIXI.live2d;
 
 // pixi-live2d-display 需要注册 Ticker 才能驱动模型更新
@@ -28,12 +61,24 @@ function applyRenderSettings(cfg) {
 }
 
 async function initLive2D() {
-  // 读取渲染设置
+  // 读取渲染设置（含 userTransform）
   const renderCfg = (await window.greywind?.getRenderSettings?.()) || {};
   applyRenderSettings(renderCfg);
+  if (renderCfg.userScale != null) userTransform.userScale = renderCfg.userScale;
+  if (renderCfg.userOffsetX != null) userTransform.userOffsetX = renderCfg.userOffsetX;
+  if (renderCfg.userOffsetY != null) userTransform.userOffsetY = renderCfg.userOffsetY;
 
-  // 监听设置变更（即时生效）
-  window.greywind?.onRenderSettingsChanged?.((cfg) => applyRenderSettings(cfg));
+  // 监听设置变更（即时生效，含重置）
+  window.greywind?.onRenderSettingsChanged?.((cfg) => {
+    applyRenderSettings(cfg);
+    // 处理来自设置页的重置操作
+    if (cfg.userScale != null || cfg.userOffsetX != null || cfg.userOffsetY != null) {
+      if (cfg.userScale != null) userTransform.userScale = cfg.userScale;
+      if (cfg.userOffsetX != null) userTransform.userOffsetX = cfg.userOffsetX;
+      if (cfg.userOffsetY != null) userTransform.userOffsetY = cfg.userOffsetY;
+      applyUserTransform(live2dModel);
+    }
+  });
 
   const dpr = renderCfg.hiDpi ? (window.devicePixelRatio || 1) : 1;
   const app = new PIXI.Application({
@@ -103,6 +148,8 @@ async function initLive2D() {
       document.body.dataset.modelReady = "true";
       modelBaseWidth = model.internalModel.originalWidth;
       modelBaseHeight = model.internalModel.originalHeight;
+      // 切换模型时重置用户偏移，避免旧模型的偏移量污染新模型
+      userTransform = { userScale: 1.0, userOffsetX: 0, userOffsetY: 0 };
       fitModel(app, model);
       app.stage.addChild(model);
       if (placeholder) placeholder.style.display = "none";
@@ -127,9 +174,11 @@ function fitModel(app, model) {
   // 全屏窗口：模型按原比例缩放，定位到屏幕右下角
   const targetH = app.screen.height * 0.85;
   const scale = targetH / modelBaseHeight;
-  model.scale.set(scale);
-  model.x = app.screen.width - modelBaseWidth * scale - 20;
-  model.y = app.screen.height - modelBaseHeight * scale - 20;
+  modelBaseScale = scale;
+  modelFitX = app.screen.width - modelBaseWidth * scale - 20;
+  modelFitY = app.screen.height - modelBaseHeight * scale - 20;
+  // 叠加用户缩放和位置偏移
+  applyUserTransform(model);
 }
 
 // 表情：根据状态调整参数
@@ -165,6 +214,28 @@ initLive2D();
 
   const dragOverlay = document.getElementById("drag-overlay");
 
+  // ── Ctrl+滚轮缩放 ──
+  dragOverlay.addEventListener("wheel", (e) => {
+    if (!e.ctrlKey || !live2dModel) return;
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? -SCALE_STEP : SCALE_STEP;
+    const newUserScale = Math.max(SCALE_MIN, Math.min(SCALE_MAX,
+      userTransform.userScale + delta));
+    if (newUserScale === userTransform.userScale) return;
+    const mx = e.clientX;
+    const my = e.clientY;
+    const oldScale = modelBaseScale * userTransform.userScale;
+    const newScale = modelBaseScale * newUserScale;
+    const ratio = newScale / oldScale;
+    const newX = mx - (mx - live2dModel.x) * ratio;
+    const newY = my - (my - live2dModel.y) * ratio;
+    userTransform.userScale = newUserScale;
+    userTransform.userOffsetX = newX - modelFitX;
+    userTransform.userOffsetY = newY - modelFitY;
+    applyUserTransform(live2dModel);  // 统一路径，不直接操作模型属性
+    saveTransformDebounced();
+  }, { passive: false });
+
   // 拖拽模型（不移动窗口）
   dragOverlay.addEventListener("pointerdown", (e) => {
     if (e.button !== 0 || !live2dModel) return;
@@ -179,11 +250,19 @@ initLive2D();
 
   dragOverlay.addEventListener("pointermove", (e) => {
     if (!dragging || !live2dModel) return;
-    live2dModel.x = modelStartX + (e.clientX - dragStartX);
-    live2dModel.y = modelStartY + (e.clientY - dragStartY);
+    const newX = modelStartX + (e.clientX - dragStartX);
+    const newY = modelStartY + (e.clientY - dragStartY);
+    userTransform.userOffsetX = newX - modelFitX;
+    userTransform.userOffsetY = newY - modelFitY;
+    applyUserTransform(live2dModel);
   });
 
   function onDragEnd() {
+    if (dragging && live2dModel) {
+      userTransform.userOffsetX = live2dModel.x - modelFitX;
+      userTransform.userOffsetY = live2dModel.y - modelFitY;
+      saveTransformDebounced();
+    }
     dragging = false;
     dragOverlay.style.cursor = "grab";
   }

--- a/frontend/desktop/renderer/settings.html
+++ b/frontend/desktop/renderer/settings.html
@@ -119,6 +119,13 @@
   </div>
 
   <div class="field">
+    <label>模型位置和大小</label>
+    <button class="btn btn-secondary" id="reset_model_transform_btn">重置位置和大小</button>
+    <div class="hint">Ctrl + 滚轮可缩放模型，拖拽可移动模型，位置和大小自动保存。</div>
+    <div id="reset_model_status" style="font-size:12px;margin-top:4px;"></div>
+  </div>
+
+  <div class="field">
     <label class="toggle">
       <input type="checkbox" id="enabled" />
       启用屏幕感知
@@ -503,6 +510,24 @@
       if (!cfg) return;
       document.getElementById("hi_dpi").checked = !!cfg.hiDpi;
       document.getElementById("bubble_blur").checked = cfg.bubbleBlur !== false;
+    });
+
+    // 重置模型位置和大小
+    const resetBtn = document.getElementById("reset_model_transform_btn");
+    resetBtn.addEventListener("click", async () => {
+      const statusEl = document.getElementById("reset_model_status");
+      resetBtn.disabled = true;
+      try {
+        await window.settingsAPI.resetModelTransform();
+        statusEl.textContent = "已重置";
+        statusEl.style.color = "#68d391";
+        setTimeout(() => { statusEl.textContent = ""; }, 2000);
+      } catch (e) {
+        statusEl.textContent = "重置失败: " + e.message;
+        statusEl.style.color = "#fc8181";
+      } finally {
+        resetBtn.disabled = false;
+      }
     });
 
     // ── 桌面操控设置 ──


### PR DESCRIPTION
## 功能

Ctrl+滚轮缩放 Live2D 模型，以鼠标为中心，位置和大小自动持久化。

## 改动

- Ctrl+滚轮缩放，范围 0.3x~3.0x
- 拖拽/缩放后自动保存到 render-settings.json，重启恢复
- 设置页新增"重置位置和大小"按钮
- 模型切换时重置用户偏移

## 测试

1. 鼠标移到模型上，Ctrl+滚轮缩放
2. 拖拽模型，重启确认位置恢复
3. 设置页点击重置，确认模型回到右下角默认位置